### PR TITLE
Fix typo in heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# litmus_image
+# litmusimage
 This repository creates docker image files, for testing puppet modules with services with [Puppet Litmus](https://github.com/puppetlabs/puppet_litmus/wiki).
 
 The images have initd, systemd or upstart, along with SSH.


### PR DESCRIPTION
litmusimage was formerly known as litmus_image, but docker(hub) doesn't allow underscores in organisation names.