### PR TITLE
Add BASE_IMAGE_TAG=${TAG} instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ necessary][3].
 docker build --rm --no-cache -t litmusimage/$IMAGE:$TAG . -f $DOCKERFILE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG --build-arg OS_TYPE=$BASE_IMAGE
 ```
 
-For example with `BASE_IMAGE=ubuntu`, `DOCKERFILE=apt_initd_dockerfile`,
-`IMAGE=ubuntu` and `TAG=14.04`:
+For example with `BASE_IMAGE=ubuntu`, `DOCKERFILE=apt_initd_dockerfile`, `IMAGE=ubuntu`, `TAG=14.04`, and `BASE_IMAGE_TAG=${TAG}`
 
 ```
 docker build --rm --no-cache -t litmusimage/ubuntu:14.04 . -f apt_initd_dockerfile --build-arg BASE_IMAGE_TAG=14.04 --build-arg OS_TYPE=ubuntu


### PR DESCRIPTION
Without the extra ``BUILD_IMAGE_TAG=${TAG}`` setting the example build fails:

```bash
➜  litmusimage git:(master) 
BASE_IMAGE=ubuntu
DOCKERFILE=apt_initd_dockerfile
IMAGE=ubuntu
TAG=14.04
docker build --rm --no-cache -t litmusimage/$IMAGE:$TAG . -f $DOCKERFILE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG --build-arg OS_TYPE=$BASE_IMAGE
[+] Building 0.1s (2/2) FINISHED                                                                                                                                                                   
 => [internal] load build definition from apt_initd_dockerfile                                                                                                                                0.0s
 => => transferring dockerfile: 548B                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                               0.0s
failed to solve with frontend dockerfile.v0: failed to create LLB definition: failed to parse stage name "ubuntu:": invalid reference format
➜  litmusimage git:(master) 
```

However, setting ``BASE_IMAGE_TAG=${TAG}`` and the build completes:

```bash
➜  litmusimage git:(master) 
BASE_IMAGE=ubuntu
DOCKERFILE=apt_initd_dockerfile
IMAGE=ubuntu
TAG=14.04
BASE_IMAGE_TAG=${TAG}
docker build --rm --no-cache -t litmusimage/$IMAGE:$TAG . -f $DOCKERFILE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG --build-arg OS_TYPE=$BASE_IMAGE
[+] Building 29.2s (8/8) FINISHED                                                                                                                                                                  
 => [internal] load build definition from apt_initd_dockerfile                                                                                                                                0.0s
 => => transferring dockerfile: 548B                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/ubuntu:14.04                                                                                                                               2.5s
 => [1/4] FROM docker.io/library/ubuntu:14.04@sha256:4a8a6fa8810a3e01352981b35165b0b28403fe2a4e2535e315b23b4a69cd130a                                                                        16.6s
 => => resolve docker.io/library/ubuntu:14.04@sha256:4a8a6fa8810a3e01352981b35165b0b28403fe2a4e2535e315b23b4a69cd130a                                                                         0.0s
 => => sha256:0551a797c01db074ab0233ceb567e66b8ebdcb9de9a2e7baa36d57dfbca463a3 72.66kB / 72.66kB                                                                                              0.9s
 => => sha256:512123a864da5e2a62949e65b67106292c5c704eff90cac2b949fc8d7ac1e58e 189B / 189B                                                                                                    0.9s
 => => sha256:4a8a6fa8810a3e01352981b35165b0b28403fe2a4e2535e315b23b4a69cd130a 1.20kB / 1.20kB                                                                                                0.0s
 => => sha256:881afbae521c910f764f7187dbfbca3cc10c26f8bafa458c76dda009a901c29d 945B / 945B                                                                                                    0.0s
 => => sha256:13b66b487594a1f2b75396013bc05d29d9f527852d96c5577cc4f187559875d0 3.31kB / 3.31kB                                                                                                0.0s
 => => sha256:2e6e20c8e2e69fa5c3fcc310f419975cef5fbeb6f7f2fe1374071141281b6a06 70.69MB / 70.69MB                                                                                             12.5s
 => => extracting sha256:2e6e20c8e2e69fa5c3fcc310f419975cef5fbeb6f7f2fe1374071141281b6a06                                                                                                     3.7s
 => => extracting sha256:0551a797c01db074ab0233ceb567e66b8ebdcb9de9a2e7baa36d57dfbca463a3                                                                                                     0.1s
 => => extracting sha256:512123a864da5e2a62949e65b67106292c5c704eff90cac2b949fc8d7ac1e58e                                                                                                     0.0s
 => [2/4] RUN apt-get update     && apt-get install -y wget locales apt-transport-https                                                                                                       8.2s
 => [3/4] RUN rm /usr/sbin/policy-rc.d     && rm /sbin/initctl     && dpkg-divert --rename --remove /sbin/initctl     && locale-gen en_US.UTF-8                                               1.2s
 => [4/4] RUN sed -i "s/.*mesg\s.*/tty -s \&\& mesg n/g" /root/.profile                                                                                                                       0.4s 
 => exporting to image                                                                                                                                                                        0.1s 
 => => exporting layers                                                                                                                                                                       0.1s 
 => => writing image sha256:81ec2c767650ddf08e29100ddea80b33cdc687fd35e4a5b7a03df5bc0b869b45                                                                                                  0.0s
 => => naming to docker.io/litmusimage/ubuntu:14.04     
➜  litmusimage git:(master) 
```