### PR TITLE
(maint) Remove individual maintainer

### DIFF
--- a/apt_initd_dockerfile
+++ b/apt_initd_dockerfile
@@ -2,7 +2,6 @@ ARG BASE_IMAGE_TAG
 ARG OS_TYPE
 
 FROM $OS_TYPE:$BASE_IMAGE_TAG
-MAINTAINER "TP Honey" tp@puppet.com
 
 RUN apt-get update \
     && apt-get install -y wget locales apt-transport-https

--- a/apt_systemd_dockerfile
+++ b/apt_systemd_dockerfile
@@ -2,7 +2,6 @@ ARG BASE_IMAGE_TAG
 ARG OS_TYPE
 
 FROM $OS_TYPE:$BASE_IMAGE_TAG
-MAINTAINER "TP Honey" tp@puppet.com
 
 ENV container docker
 ENV DEBIAN_FRONTEND noninteractive

--- a/apt_sysvinit-utils_dockerfile
+++ b/apt_sysvinit-utils_dockerfile
@@ -2,7 +2,6 @@ ARG BASE_IMAGE_TAG
 ARG OS_TYPE
 
 FROM $OS_TYPE:$BASE_IMAGE_TAG
-MAINTAINER "TP Honey" tp@puppet.com
 
 ENV container docker
 ENV DEBIAN_FRONTEND noninteractive

--- a/yum_initd_dockerfile
+++ b/yum_initd_dockerfile
@@ -4,7 +4,6 @@ ARG OS_TYPE
 FROM $OS_TYPE:$BASE_IMAGE_TAG
 
 ENV container docker
-MAINTAINER "TP Honey" tp@puppet.com
 
 # the seds fail when the files are not available - ignore the error code
 RUN sed -i -e 's/mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/CentOS-Base.repo /etc/yum.repos.d/CentOS-fasttrack.repo; \

--- a/yum_systemd_dockerfile
+++ b/yum_systemd_dockerfile
@@ -4,7 +4,6 @@ ARG OS_TYPE
 FROM $OS_TYPE:$BASE_IMAGE_TAG
 
 ENV container docker
-MAINTAINER "TP Honey" tp@puppet.com
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*;\


### PR DESCRIPTION
According to the docs MAINTAINER is now deprecated: https://docs.docker.com/engine/reference/builder/