### PR TITLE
(IAC-1710) - Addition of Debian 11 Bullseye

### DIFF
--- a/.github/workflows/build_dockerfiles.yml
+++ b/.github/workflows/build_dockerfiles.yml
@@ -25,6 +25,7 @@ jobs:
         - { IMAGE: 'debian', TAG: '8', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '8' }
         - { IMAGE: 'debian', TAG: '9', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '9' }
         - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }
+        - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '11' }
     env: ${{ matrix.env }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/build_dockerfiles.yml
+++ b/.github/workflows/build_dockerfiles.yml
@@ -25,7 +25,7 @@ jobs:
         - { IMAGE: 'debian', TAG: '8', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '8' }
         - { IMAGE: 'debian', TAG: '9', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '9' }
         - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }
-        - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '11' }
+        - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: 'bullseye' }
     env: ${{ matrix.env }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,7 @@ jobs:
         - { IMAGE: 'debian', TAG: '8', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '8' }
         - { IMAGE: 'debian', TAG: '9', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '9' }
         - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }
+        - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '11' }
     env: ${{ matrix.env }}
     steps:
       - name: Docker login

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
         - { IMAGE: 'debian', TAG: '8', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '8' }
         - { IMAGE: 'debian', TAG: '9', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '9' }
         - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }
-        - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '11' }
+        - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: 'bullseye' }
     env: ${{ matrix.env }}
     steps:
       - name: Docker login

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -28,6 +28,7 @@ jobs:
         - { IMAGE: 'debian', TAG: '8', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '8' }
         - { IMAGE: 'debian', TAG: '9', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '9' }
         - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }
+        - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '11' }
     env: ${{ matrix.env }}
     steps:
       - name: Docker login

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -28,7 +28,7 @@ jobs:
         - { IMAGE: 'debian', TAG: '8', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '8' }
         - { IMAGE: 'debian', TAG: '9', DOCKERFILE: 'apt_systemd_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '9' }
         - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }
-        - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '11' }
+        - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: 'bullseye' }
     env: ${{ matrix.env }}
     steps:
       - name: Docker login


### PR DESCRIPTION
Due to `11` not existing currently as a tag on the Debian docker hub, `bullseye` has been used in its place.
As the tag that we call when provisioning is set separately this should have no negative effects.

https://hub.docker.com/_/debian