### PR TITLE
(GH-36) - Ensure `iproute` is installed

### DIFF
--- a/yum_systemd_dockerfile
+++ b/yum_systemd_dockerfile
@@ -15,7 +15,7 @@ rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN echo "LC_ALL=en_US.utf-8" >> /etc/locale.conf
-RUN yum -y install openssh-server openssh-clients initscripts glibc-langpack-en; yum -y reinstall dbus; yum clean all; systemctl enable sshd.service
+RUN yum -y install openssh-server openssh-clients initscripts glibc-langpack-en iproute; yum -y reinstall dbus; yum clean all; systemctl enable sshd.service
 
 EXPOSE 22
 


### PR DESCRIPTION
`iproute` is not included by default on AlmaLinux and Rocky Linux 8