### PR TITLE
(GH-cat-8) Move CentOS 8 support to CentOS Stream 8

### DIFF
--- a/.github/workflows/build_dockerfiles.yml
+++ b/.github/workflows/build_dockerfiles.yml
@@ -16,7 +16,7 @@ jobs:
         - { IMAGE: 'ubuntu', TAG: '22.04', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'ubuntu', BASE_IMAGE_TAG: '22.04' }
         - { IMAGE: 'centos', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'centos', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '7' }
-        - { IMAGE: 'centos', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream8' }
+        - { IMAGE: 'centos', TAG: 'stream8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream8' }
         - { IMAGE: 'scientificlinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'scientificlinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '7' }
         - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
         - { IMAGE: 'ubuntu', TAG: '22.04', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'ubuntu', BASE_IMAGE_TAG: '22.04' }
         - { IMAGE: 'centos', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'centos', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '7' }
-        - { IMAGE: 'centos', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream8' }
+        - { IMAGE: 'centos', TAG: 'stream8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream8' }
         - { IMAGE: 'scientificlinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'scientificlinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '7' }
         - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -19,7 +19,7 @@ jobs:
         - { IMAGE: 'ubuntu', TAG: '22.04', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'ubuntu', BASE_IMAGE_TAG: '22.04' }
         - { IMAGE: 'centos', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'centos', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '7' }
-        - { IMAGE: 'centos', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream8' }
+        - { IMAGE: 'centos', TAG: 'stream8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream8' }
         - { IMAGE: 'scientificlinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'scientificlinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '7' }
         - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }


### PR DESCRIPTION
As CentOS 8 is no longer supported by CentOS themselves we are officially moving support over to Stream 8 instead