### PR TITLE
Add CentOS Stream 9 image

### DIFF
--- a/.github/workflows/build_dockerfiles.yml
+++ b/.github/workflows/build_dockerfiles.yml
@@ -17,6 +17,7 @@ jobs:
         - { IMAGE: 'centos', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'centos', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '7' }
         - { IMAGE: 'centos', TAG: 'stream8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream8' }
+        - { IMAGE: 'centos', TAG: 'stream9', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream9' }
         - { IMAGE: 'scientificlinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'scientificlinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '7' }
         - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ jobs:
         - { IMAGE: 'centos', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'centos', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '7' }
         - { IMAGE: 'centos', TAG: 'stream8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream8' }
+        - { IMAGE: 'centos', TAG: 'stream9', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream9' }
         - { IMAGE: 'scientificlinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'scientificlinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '7' }
         - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -20,6 +20,7 @@ jobs:
         - { IMAGE: 'centos', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'centos', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'centos', BASE_IMAGE_TAG: '7' }
         - { IMAGE: 'centos', TAG: 'stream8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream8' }
+        - { IMAGE: 'centos', TAG: 'stream9', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'quay.io/centos/centos', BASE_IMAGE_TAG: 'stream9' }
         - { IMAGE: 'scientificlinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '6' }
         - { IMAGE: 'scientificlinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '7' }
         - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ necessary][3].
 | ubuntu | 20.04 | apt_sysvinit-utils_dockerfile | ubuntu | 20.04 |
 | centos | 6 | yum_initd_dockerfile | centos | 6 |
 | centos | 7 | yum_systemd_dockerfile | centos | 7 |
-| centos | 8 | yum_systemd_dockerfile | centos | 8 |
+| centos | stream8 | yum_systemd_dockerfile | centos | stream8 |
+| centos | stream9 | yum_systemd_dockerfile | centos | stream9 |
 | scientificlinux | 6 | yum_initd_dockerfile | scientificlinux/sl | 6 |
 | scientificlinux | 7 | yum_systemd_dockerfile | scientificlinux/sl | 7 |
 | oraclelinux | 6 | yum_initd_dockerfile | oraclelinux | 6 |


### PR DESCRIPTION
This change introduces the CentOS Stream 9 image, so that the behavior in CentOS Stream 9 can be tested by the litmus test tool.