### PR TITLE
(MAINT) Set fail-fast to false

### DIFF
--- a/.github/workflows/build_dockerfiles.yml
+++ b/.github/workflows/build_dockerfiles.yml
@@ -7,6 +7,7 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         env:
         - { IMAGE: 'ubuntu', TAG: '14.04', DOCKERFILE: 'apt_initd_dockerfile', BASE_IMAGE: 'ubuntu', BASE_IMAGE_TAG: '14.04' }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,7 @@ jobs:
     name: build
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         env:
         - { IMAGE: 'ubuntu', TAG: '14.04', DOCKERFILE: 'apt_initd_dockerfile', BASE_IMAGE: 'ubuntu', BASE_IMAGE_TAG: '14.04' }

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -10,6 +10,7 @@ jobs:
     name: build
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         env:
         - { IMAGE: 'ubuntu', TAG: '14.04', DOCKERFILE: 'apt_initd_dockerfile', BASE_IMAGE: 'ubuntu', BASE_IMAGE_TAG: '14.04' }


### PR DESCRIPTION
Prior to this PR a single failing job in the matrix would cause all other jobs to halt. This has been preventing images from being updated.

This PR sets `strategy.fail-fast` to `false` so that jobs in the matrix can continue when others fail.