### PR TITLE
Add newer oraclelinux images

### DIFF
--- a/.github/workflows/build_dockerfiles.yml
+++ b/.github/workflows/build_dockerfiles.yml
@@ -21,6 +21,7 @@ jobs:
           - { IMAGE: 'scientificlinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '7' }
           - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }
           - { IMAGE: 'oraclelinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '7' }
+          - { IMAGE: 'oraclelinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'rockylinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'rockylinux/rockylinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'almalinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'almalinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }

--- a/.github/workflows/build_dockerfiles.yml
+++ b/.github/workflows/build_dockerfiles.yml
@@ -22,6 +22,7 @@ jobs:
           - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }
           - { IMAGE: 'oraclelinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '7' }
           - { IMAGE: 'oraclelinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '8' }
+          - { IMAGE: 'oraclelinux', TAG: '9', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '9' }
           - { IMAGE: 'rockylinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'rockylinux/rockylinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'almalinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'almalinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,7 @@ jobs:
           - { IMAGE: 'scientificlinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '7' }
           - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }
           - { IMAGE: 'oraclelinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '7' }
+          - { IMAGE: 'oraclelinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'rockylinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'rockylinux/rockylinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'almalinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'almalinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,7 @@ jobs:
           - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }
           - { IMAGE: 'oraclelinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '7' }
           - { IMAGE: 'oraclelinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '8' }
+          - { IMAGE: 'oraclelinux', TAG: '9', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '9' }
           - { IMAGE: 'rockylinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'rockylinux/rockylinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'almalinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'almalinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -25,6 +25,7 @@ jobs:
           - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }
           - { IMAGE: 'oraclelinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '7' }
           - { IMAGE: 'oraclelinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '8' }
+          - { IMAGE: 'oraclelinux', TAG: '9', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '9' }
           - { IMAGE: 'rockylinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'rockylinux/rockylinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'almalinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'almalinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -24,6 +24,7 @@ jobs:
           - { IMAGE: 'scientificlinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'scientificlinux/sl', BASE_IMAGE_TAG: '7' }
           - { IMAGE: 'oraclelinux', TAG: '6', DOCKERFILE: 'yum_initd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '6' }
           - { IMAGE: 'oraclelinux', TAG: '7', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '7' }
+          - { IMAGE: 'oraclelinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'rockylinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'rockylinux/rockylinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'almalinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'almalinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ necessary][3].
 | oraclelinux | 6 | yum_initd_dockerfile | oraclelinux | 6 |
 | oraclelinux | 7 | yum_systemd_dockerfile | oraclelinux | 7 |
 | oraclelinux | 7 | yum_systemd_dockerfile | oraclelinux | 7 |
+| oraclelinux | 8 | yum_systemd_dockerfile | oraclelinux | 8 |
 | rockylinux | 8 | yum_systemd_dockerfile | rockylinux/rockylinux | 8 |
 | almalinux | 8 | yum_systemd_dockerfile | almalinux | 8 |
 | debian | 10 | apt_sysvinit-utils_dockerfile | debian | 10 |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ necessary][3].
 | oraclelinux | 7 | yum_systemd_dockerfile | oraclelinux | 7 |
 | oraclelinux | 7 | yum_systemd_dockerfile | oraclelinux | 7 |
 | oraclelinux | 8 | yum_systemd_dockerfile | oraclelinux | 8 |
+| oraclelinux | 9 | yum_systemd_dockerfile | oraclelinux | 9 |
 | rockylinux | 8 | yum_systemd_dockerfile | rockylinux/rockylinux | 8 |
 | almalinux | 8 | yum_systemd_dockerfile | almalinux | 8 |
 | debian | 10 | apt_sysvinit-utils_dockerfile | debian | 10 |


### PR DESCRIPTION
Add `oraclelinux:8` and `oraclelinux:9` for use with Litmus.