### PR TITLE
Add rockylinux:9 and almalinux:9

### DIFF
--- a/.github/workflows/build_dockerfiles.yml
+++ b/.github/workflows/build_dockerfiles.yml
@@ -24,7 +24,9 @@ jobs:
           - { IMAGE: 'oraclelinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '8' }
           - { IMAGE: 'oraclelinux', TAG: '9', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'oraclelinux', BASE_IMAGE_TAG: '9' }
           - { IMAGE: 'rockylinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'rockylinux/rockylinux', BASE_IMAGE_TAG: '8' }
+          - { IMAGE: 'rockylinux', TAG: '9', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'rockylinux/rockylinux', BASE_IMAGE_TAG: '9' }
           - { IMAGE: 'almalinux', TAG: '8', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'almalinux', BASE_IMAGE_TAG: '8' }
+          - { IMAGE: 'almalinux', TAG: '9', DOCKERFILE: 'yum_systemd_dockerfile', BASE_IMAGE: 'almalinux', BASE_IMAGE_TAG: '9' }
           - { IMAGE: 'debian', TAG: '10', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '10' }
           - { IMAGE: 'debian', TAG: '11', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: 'bullseye' }
           - { IMAGE: 'debian', TAG: '12', DOCKERFILE: 'apt_sysvinit-utils_dockerfile', BASE_IMAGE: 'debian', BASE_IMAGE_TAG: '12' }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ necessary][3].
 | oraclelinux | 8 | yum_systemd_dockerfile | oraclelinux | 8 |
 | oraclelinux | 9 | yum_systemd_dockerfile | oraclelinux | 9 |
 | rockylinux | 8 | yum_systemd_dockerfile | rockylinux/rockylinux | 8 |
+| rockylinux | 9 | yum_systemd_dockerfile | rockylinux/rockylinux | 9 |
 | almalinux | 8 | yum_systemd_dockerfile | almalinux | 8 |
+| almalinux | 9 | yum_systemd_dockerfile | almalinux | 9 |
 | debian | 10 | apt_sysvinit-utils_dockerfile | debian | 10 |
 | debian | 11 | apt_sysvinit-utils_dockerfile | debian | bullseye |
 | amazonlinux | 2 | yum_systemd_dockerfile | amazonlinux | 2 |


### PR DESCRIPTION
## Summary
Adds rockylinux:9 and almalinux:9

## Additional Context
I ran the build manually for each one successfully. No changes were needed from the 8 versions.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified.
