### PR TITLE
add post build smoke test

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -6,6 +6,7 @@ run-name: >
   ${{ inputs.dockerfile && format('dockerfile={0}', inputs.dockerfile) || '' }}
   ${{ inputs.refresh && format('refresh={0}', inputs.refresh) || '' }}
   ${{ inputs.push && format('push={0}', inputs.push) || ''}}
+  ${{ inputs.puppet_litmus && format('puppet_litmus={0}', inputs.puppet_litmus) || '' }}
 
 on:
   workflow_dispatch:
@@ -26,6 +27,10 @@ on:
         description: push to registry (default branch only)
         type: boolean
         default: true
+      puppet_litmus:
+        description: gem options (JSON Hash)
+        type: string
+        default: ""
 
 jobs:
   manual:
@@ -36,3 +41,4 @@ jobs:
       dockerfile: ${{ inputs.dockerfile }}
       refresh: ${{ inputs.refresh == true }}
       push: ${{ inputs.push == true }}
+      puppet_litmus: ${{ inputs.puppet_litmus }}

--- a/.github/workflows/template_build_deploy.yml
+++ b/.github/workflows/template_build_deploy.yml
@@ -1,5 +1,5 @@
 ---
-name: template - build and deploy
+name: template - build, test and deploy
 
 on:
   workflow_call:
@@ -16,6 +16,9 @@ on:
       push:
         type: boolean
         default: true
+      puppet_litmus:
+        default: ""
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,6 +29,8 @@ env:
   REGISTRY_USERNAME: ${{ vars.DOCKER_USERNAME != '' && vars.DOCKER_USERNAME || github.actor }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_PASSWORD || secrets.GITHUB_TOKEN }}
   REPOSITORY: ${{ vars.DOCKER_REPOSITORY != '' && vars.DOCKER_REPOSITORY || github.repository }}
+  BOLT_GEM: 1
+  GEM_PUPPET_LITMUS: ${{ github.event.inputs.puppet_litmus }}
 
 jobs:
   select:
@@ -35,6 +40,26 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       push: ${{ steps.branch-names.outputs.is_default }}
     steps:
+      - name: Validate inputs
+        shell: ruby {0}
+        run: |
+          require 'json'
+          def valid_json?(data)
+            !!(JSON.parse(data) || true) rescue false
+          end
+          event = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
+          event['inputs'].select! do |key, val|
+            next if val.nil? || val.empty?
+            case key
+            when "puppet_litmus"
+              !valid_json?(val) || val.match?(%r{[();]})
+            end
+          end
+          event['inputs'].each do |key, value|
+            puts "::error title=#{key} invalid::#{value}"
+          end
+          exit 1 unless event['inputs'].empty?
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -100,7 +125,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 10
       fail-fast: false
@@ -140,20 +165,59 @@ jobs:
           fi
           echo "need_refresh=true" >> $GITHUB_OUTPUT
 
-      - if: steps.compare_image.outputs.need_refresh || steps.compare_image.outcome == 'skipped'
-        name: Checkout repository
+      - name: Checkout repository
         id: checkout_repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - if: steps.checkout_repo.conclusion == 'success'
+      - if: steps.compare_image.outputs.need_refresh || steps.compare_image.outcome == 'skipped'
         name: Build ${{ matrix.image_tag }}
         id: build_image
         run: |
           docker build --rm --no-cache -t ${IMAGE_TAG} . --label "base_image=${BASE_ID}" -f ${{ matrix.dockerfile }}.dockerfile --build-arg BASE_IMAGE_TAG=${{ matrix.base_tag }} --build-arg OS_TYPE=${{ matrix.base_image }}
 
-      - if: steps.build_image.conclusion == 'success'  && needs.select.outputs.push == 'true'
+      - name: Smoke test setup
+        if: steps.build_image.outcome == 'success' || steps.build_image.conclusion == 'skipped'
+        id: test_ruby_setup
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: tests/smoke
+
+      - name: Smoke test
+        if: steps.test_ruby_setup.outcome == 'success'
+        id: test_image
+        continue-on-error: true
+        working-directory: tests/smoke
+        timeout-minutes: 4
+        run: |
+          bundle info puppet_litmus
+          echo ::group::bolt module install
+          bundle exec bolt module install
+          echo ::endgroup::
+          echo ::group::rake listmus:provision
+          bundle exec rake litmus:provision[docker,${IMAGE_TAG}]
+          echo ::endgroup::
+          bundle exec bolt command run 'last' -t all
+
+        # Previous step should always continue on error
+        # so docker logs will be added to the output
+      - name: Smoke test cleanup
+        if: steps.test_image.conclusion == 'success'
+        working-directory: tests/smoke
+        run: |
+          set +e
+          echo ::group::Bolt inventory
+          bundle exec bolt inventory show --detail
+          echo ::endgroup::
+          docker ps -a --format '{{.ID}}' | xargs -n1 docker logs
+          bundle exec rake litmus:tear_down
+          # ALWAYS exit based on the outcode of the smoke test provision
+          exit ${{ steps.test_image.outcome != 'success' && '1' || '0' }}
+
+      - if: steps.build_image.outcome == 'success' && steps.test_image.outcome == 'success' && needs.select.outputs.push == 'true'
         name: Push ${{ matrix.image_tag }} to ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
         run: |
           docker image push $IMAGE_TAG

--- a/tests/smoke/.gitignore
+++ b/tests/smoke/.gitignore
@@ -1,0 +1,8 @@
+/.bundle
+/.resource_types
+/.*.json
+/*.log
+/spec
+/Gemfile.lock
+/.modules
+/Puppetfile

--- a/tests/smoke/Gemfile
+++ b/tests/smoke/Gemfile
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+require 'json'
+
+if ENV.fetch('GEM_PUPPET_LITMUS', '').empty?
+  gem 'puppet_litmus'
+else
+  gem 'puppet_litmus', JSON.parse(ENV['GEM_PUPPET_LITMUS'])
+end
+
+gem 'puppetlabs_spec_helper'
+gem 'rake'
+gem 'ed25519'
+gem 'bcrypt_pbkdf'

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -1,0 +1,39 @@
+# Litmusimage Smoke Tests
+
+[Puppet litmus](https://github.com/puppetlabs/puppet_litmus/) is used to test
+the docker images maintained by this project. The Github Action [workflow](../../../template_build_deploy.yml)
+contains steps to setup, provision, and run a simple command.
+
+### Testing
+
+These steps are not guaranteed to perform the exact steps in the
+CI workflow, but should generally function to debug image builds
+locally.
+
+__Requires Ruby 3+ and Docker on the test host.__
+
+1. Setup
+   ```sh
+   bundle config set --local path .bundle/vendor
+   bundle exec bolt module install
+   ```
+2. Provision and Test
+   ```sh
+   bundle exec rake litmus:provision[docker,litmusimage/rockylinux:8]
+   bundle exec bolt command run 'last' -t all
+   ```
+3. Tear down
+   ```sh
+   bundle exec rake litmus:tear_down
+   ```
+
+### Debugging
+
+1. Review docker logs
+   ```sh
+   docker ps -a --format '{{.ID}}' | xargs -n1 docker logs
+   ```
+2. Review bolt inventory
+   ```sh
+   bundle exec bolt inventory show --detail
+   ```

--- a/tests/smoke/Rakefile
+++ b/tests/smoke/Rakefile
@@ -1,0 +1,3 @@
+require 'bundler'
+require 'puppet_litmus/rake_tasks'
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/tests/smoke/bolt-project.yaml
+++ b/tests/smoke/bolt-project.yaml
@@ -1,0 +1,7 @@
+---
+name: litmusimage
+analytics: false
+modules:
+  - name: puppetlabs/provision
+    git: https://github.com/h0tw1r3/provision.git
+    ref: h0tw1r3

--- a/tests/smoke/inventory.yaml
+++ b/tests/smoke/inventory.yaml
@@ -1,0 +1,1 @@
+spec/fixtures/litmus_inventory.yaml

--- a/tests/smoke/rakelib/fixtures.rake
+++ b/tests/smoke/rakelib/fixtures.rake
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Create fixture symlink for all bolt project modules
+
+# Returns fixture symlinks hash in the same format as
+# PuppetlabsSpecHelper::Tasks::FixtureHelpers
+def bolt_fixture_symlinks
+  @bolt_fixture_symlinks ||= Dir.glob('.modules/*').select { |f| File.directory? f }.to_h do |d|
+    [
+      File.realpath(d),
+      { 'target' => "spec/fixtures/modules/#{File.basename(d)}" },
+    ]
+  end
+
+  @bolt_fixture_symlinks
+end
+
+task :spec_prep_bolt_modules do
+  bolt_fixture_symlinks.each do |target, link|
+    setup_symlink(target, link)
+  end
+end
+
+task :spec_clean_bolt_symlinks do
+  bolt_fixture_symlinks.each do |_source, opts|
+    target = opts['target']
+    FileUtils.rm_f(target)
+  end
+end
+
+Rake::Task['spec_prep'].enhance do
+  Rake::Task['spec_prep_bolt_modules'].invoke
+end
+
+Rake::Task['spec_clean_symlinks'].enhance do
+  Rake::Task['spec_clean_bolt_symlinks'].invoke
+end


### PR DESCRIPTION
Workflow puppet_litmus_gem input as JSON is expanded in smoke test Gemfile to support testing pre-release puppet_litmus provision changes

For example, [this workflow](https://github.com/h0tw1r3/litmusimage/actions/runs/7882461002) runs smoke test with a fork of the puppet_litmus gem provisioning unprivileged docker containers.
