### PR TITLE
Smoke test provision module option

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -7,6 +7,7 @@ run-name: >
   ${{ inputs.refresh && format('refresh={0}', inputs.refresh) || '' }}
   ${{ inputs.push && format('push={0}', inputs.push) || ''}}
   ${{ inputs.puppet_litmus && format('puppet_litmus={0}', inputs.puppet_litmus) || '' }}
+  ${{ inputs.provision_module && format('provision_module={0}', inputs.provision_module) || '' }}
 
 on:
   workflow_dispatch:
@@ -31,6 +32,10 @@ on:
         description: gem options (JSON Hash)
         type: string
         default: ""
+      provision_module:
+        description: provision module overrides (JSON Hash)
+        type: string
+        default: ""
 
 jobs:
   manual:
@@ -42,3 +47,4 @@ jobs:
       refresh: ${{ inputs.refresh == true }}
       push: ${{ inputs.push == true }}
       puppet_litmus: ${{ inputs.puppet_litmus }}
+      provision_module: ${{ inputs.provision_module }}

--- a/.github/workflows/template_build_deploy.yml
+++ b/.github/workflows/template_build_deploy.yml
@@ -19,6 +19,9 @@ on:
       puppet_litmus:
         default: ""
         type: string
+      provision_module:
+        default: ""
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -51,7 +54,7 @@ jobs:
           inputs.select! do |key, val|
             next if val.nil? || val.to_s.empty?
             case key
-            when 'puppet_litmus'
+            when %r{puppet_litmus|provision_module}
               !valid_json?(val) || val.match?(%r{[();]})
             end
           end
@@ -186,6 +189,23 @@ jobs:
           bundler-cache: true
           working-directory: tests/smoke
 
+      - name: Smoke test with custom provision module
+        if: steps.test_ruby_setup.outcome == 'success' && inputs.provision_module != ''
+        working-directory: tests/smoke
+        shell: ruby {0}
+        run: |
+          require 'yaml'
+          require 'json'
+          input = <<INPUT
+          ${{ inputs.provision_module }}
+          INPUT
+          override = JSON.parse(input)
+          project = YAML.safe_load_file('bolt-project.yaml')
+          project["modules"].each_with_index do |mod, i|
+            project["modules"][i].merge!(override) if mod["name"].eql?('puppetlabs/provision')
+          end
+          File.write('bolt-project.yaml', project.to_yaml)
+
       - name: Smoke test
         if: steps.test_ruby_setup.outcome == 'success'
         id: test_image
@@ -196,6 +216,7 @@ jobs:
           bundle info puppet_litmus
           echo ::group::bolt module install
           bundle exec bolt module install
+          bundle exec bolt module show
           echo ::endgroup::
           echo ::group::rake listmus:provision
           bundle exec rake litmus:provision[docker,${IMAGE_TAG}]

--- a/tests/smoke/bolt-project.yaml
+++ b/tests/smoke/bolt-project.yaml
@@ -3,5 +3,5 @@ name: litmusimage
 analytics: false
 modules:
   - name: puppetlabs/provision
-    git: https://github.com/h0tw1r3/provision.git
-    ref: h0tw1r3
+    git: https://github.com/puppetlabs/provision.git
+    ref: main


### PR DESCRIPTION
* Set default bolt provision module to puppetlabs 😸 
* Support custom bolt provision module option. Allows us to run manual smoke tests with proposed provision module changes in the same way as the puppet_litmus gem option.