### PR TITLE
(maint) add bolt task to smoke test

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -28,6 +28,10 @@ on:
         description: push to registry (default branch only)
         type: boolean
         default: true
+      provision_task:
+        description: provision task (docker or docker_exp)
+        type: string
+        default: "docker"
       puppet_litmus:
         description: gem options (JSON Hash)
         type: string
@@ -46,5 +50,6 @@ jobs:
       dockerfile: ${{ inputs.dockerfile }}
       refresh: ${{ inputs.refresh == true }}
       push: ${{ inputs.push == true }}
+      provision_task: ${{ inputs.provision_task }}
       puppet_litmus: ${{ inputs.puppet_litmus }}
       provision_module: ${{ inputs.provision_module }}

--- a/.github/workflows/template_build_deploy.yml
+++ b/.github/workflows/template_build_deploy.yml
@@ -16,12 +16,16 @@ on:
       push:
         type: boolean
         default: true
+      provision_task:
+        default: "docker"
+        type: string
       puppet_litmus:
         default: ""
         type: string
       provision_module:
         default: ""
         type: string
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -56,6 +60,8 @@ jobs:
             case key
             when %r{puppet_litmus|provision_module}
               !valid_json?(val) || val.match?(%r{[();]})
+            when 'provision_task'
+              !/^docker(_exp)?$/.match?(val)
             end
           end
           inputs.each do |key, value|
@@ -219,9 +225,12 @@ jobs:
           bundle exec bolt module show
           echo ::endgroup::
           echo ::group::rake listmus:provision
-          bundle exec rake litmus:provision[docker,${IMAGE_TAG}]
+          bundle exec rake litmus:provision[${{ inputs.provision_task }},${IMAGE_TAG}]
           echo ::endgroup::
+          echo "testing bolt command"
           bundle exec bolt command run 'last' -t all
+          echo "testing bolt task"
+          bundle exec bolt task run litmusimage::smoke -t all
 
         # Previous step should always continue on error
         # so docker logs will be added to the output

--- a/tests/smoke/tasks/smoke.json
+++ b/tests/smoke/tasks/smoke.json
@@ -1,0 +1,9 @@
+{
+    "supports_noop": false,
+    "description": "Very simple smoke test",
+    "parameters": { },
+    "input_method": "environment",
+    "implementations": [
+        { "name": "smoke.sh", "requirements": [ "shell" ] }
+    ]
+}

--- a/tests/smoke/tasks/smoke.sh
+++ b/tests/smoke/tasks/smoke.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o pipefail -o errtrace -o errexit -o nounset -o functrace
+
+traperror() {
+    local el=${1:=??} ec=${2:=??} lc="$BASH_COMMAND"
+    errorexit "ERROR in $(basename $0) : $el error $ec : $lc" ${2:=1}
+}
+trap 'traperror ${LINENO} ${?}' ERR
+
+errorexit() {
+    echo >&2 $1
+    if [ -z ${2+x} ] ; then
+        exit 1
+    else
+        exit $2
+    fi
+}
+
+main() {
+    if [[ $(id -un) != 'root' ]]; then
+          errorexit "must be root" 1
+    fi
+
+    echo "ipsum lorem success"
+}
+
+main "$@"


### PR DESCRIPTION
Extend the smoke test to execute a Bolt task. Ensures Bolt can transfer files to the container and execute scripts.

Ideally this will identify bugs like https://github.com/puppetlabs/provision/pull/258 in the future.

* [Manual test with docker provision](https://github.com/h0tw1r3/litmusimage/actions/runs/7946973872/job/21695273297#step:10:86)
* [Manual test with docker_exp provision](https://github.com/h0tw1r3/litmusimage/actions/runs/7946959946/job/21695260596#step:10:88)