### PR TITLE
fix smoke test composite action with custom provision gem

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -17,7 +17,7 @@ inputs:
     type: string
   ruby_version:
     required: true
-    default: "2.7"
+    default: "3.2"
     type: string
 
 runs:
@@ -33,7 +33,7 @@ runs:
     - name: Custom provision module
       if: inputs.provision_module != ''
       working-directory: tests/smoke
-      shell: ruby
+      shell: ruby {0}
       run: |
         require 'yaml'
         require 'json'


### PR DESCRIPTION
When running a manual workflow with a custom provision module, workflow fails. Regression caused by #78 

To reproduce, run a manual workflow with any custom `provision_module` input, eg:
```{ "git": "https://github.com/h0tw1r3/provision.git", "ref": "dnf-support" } ```
