### PR TITLE
(maint) remove ubuntu 24.04 until official puppet-agent is available

### DIFF
--- a/images.json
+++ b/images.json
@@ -2,7 +2,6 @@
     { "image": "ubuntu",          "tag": "18.04",   "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64"],             "base_image": "ubuntu",                "base_tag": "18.04" },
     { "image": "ubuntu",          "tag": "20.04",   "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "ubuntu",                "base_tag": "20.04" },
     { "image": "ubuntu",          "tag": "22.04",   "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "ubuntu",                "base_tag": "22.04" },
-    { "image": "ubuntu",          "tag": "24.04",   "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "ubuntu",                "base_tag": "24.04" },
     { "image": "centos",          "tag": "6",       "dockerfile": "yum_initd",          "platforms": ["amd64"],             "base_image": "centos",                "base_tag": "6" },
     { "image": "centos",          "tag": "7",       "dockerfile": "yum_systemd",        "platforms": ["amd64"],             "base_image": "centos",                "base_tag": "7" },
     { "image": "centos",          "tag": "stream8", "dockerfile": "yum_systemd",        "platforms": ["amd64", "arm64/v8"], "base_image": "quay.io/centos/centos", "base_tag": "stream8" },


### PR DESCRIPTION
litmus tests always fail because the puppet-agent has not been released yet