### PR TITLE
(CAT-1901) - Handle 'No URLs in mirrorlist' error for 'appstream' repo in CentOS 8

### DIFF
--- a/yum_systemd.dockerfile
+++ b/yum_systemd.dockerfile
@@ -3,9 +3,16 @@ ARG OS_TYPE
 
 FROM $OS_TYPE:$BASE_IMAGE_TAG
 
+# Re-declare BASE_IMAGE_TAG ARG
+ARG BASE_IMAGE_TAG
+
 ENV container docker
 
 RUN echo "LC_ALL=en_US.utf-8" >> /etc/locale.conf
+
+RUN if [ "$BASE_IMAGE_TAG" = "stream8" ] ; then (cd /etc/yum.repos.d/; sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*;\
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*);\
+fi
 
 RUN yum -y install openssh-server openssh-clients systemd initscripts glibc-langpack-en iproute; yum -y reinstall dbus; yum clean all; systemctl enable sshd.service
 


### PR DESCRIPTION
## Summary
This PR addresses an issue specific to CentOS 8 where the build process fails due to an inability to download metadata for the 'appstream' repository. The error is caused by the absence of URLs in the mirrorlist. 

In CentOS 8, the 'appstream' repository is used to provide additional packages that may be needed by the system. However, due to changes in the way CentOS 8 handles repositories, the mirrorlist for 'appstream' sometimes does not contain any URLs, leading to this error.

The Dockerfile has been updated to handle this scenario by modifying the repository configuration files in '/etc/yum.repos.d/'. If the base image tag is 'stream8', the script now comments out the 'mirrorlist' line and replaces it with a 'baseurl' line pointing to 'http://vault.centos.org', ensuring that the build process can proceed without encountering the 'No URLs in mirrorlist' error.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
