### PR TITLE
(CAT-1946) - Fix failing centos7/scientific7 images

### DIFF
--- a/yum_systemd.dockerfile
+++ b/yum_systemd.dockerfile
@@ -3,15 +3,26 @@ ARG OS_TYPE
 
 FROM $OS_TYPE:$BASE_IMAGE_TAG
 
-# Re-declare BASE_IMAGE_TAG ARG
+# Re-declare OS_TYPE & BASE_IMAGE_TAG ARGS
+ARG OS_TYPE
 ARG BASE_IMAGE_TAG
 
 ENV container docker
 
 RUN echo "LC_ALL=en_US.utf-8" >> /etc/locale.conf
 
-RUN if [ "$BASE_IMAGE_TAG" = "stream8" ] ; then (cd /etc/yum.repos.d/; sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*;\
-sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*);\
+RUN if [[ ( "$OS_TYPE" = "quay.io/centos/centos" && "$BASE_IMAGE_TAG" = "stream8" ) || ( "$OS_TYPE" = "centos" && "$BASE_IMAGE_TAG" = "7" ) ]]; then \
+  for file in /etc/yum.repos.d/CentOS-*; do \
+    sed -i 's/mirrorlist/#mirrorlist/g' "$file"; \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' "$file"; \
+  done; \
+fi
+
+RUN if [[ ( "$OS_TYPE" = "scientificlinux/sl" && "$BASE_IMAGE_TAG" = "7" ) ]]; then \
+  for file in /etc/yum.repos.d/*.repo; do \
+    sed -i 's/mirrorlist/#mirrorlist/g' "$file"; \
+    sed -i 's|^baseurl=http://ftp.scientificlinux.org/linux/scientific/|baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/|g' "$file"; \
+  done; \
 fi
 
 RUN yum -y install openssh-server openssh-clients systemd initscripts glibc-langpack-en iproute; yum -y reinstall dbus; yum clean all; systemctl enable sshd.service


### PR DESCRIPTION
## Summary
switch centos7 mirror to centos vault http://vault.centos.org.
switch sl7 mirror to obsolete mirror http://ftp.scientificlinux.org/linux/scientific/obsolete/7x/

we will continue building and publishing these images until support is dropped for these OS by puppet agent

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
