### PR TITLE
(CAT-2120) Update sources with bookworm-backports repo

### DIFF
--- a/.github/workflows/template_build_deploy.yml
+++ b/.github/workflows/template_build_deploy.yml
@@ -133,7 +133,7 @@ jobs:
   images:
     needs: select
     name: image (${{ matrix.image_tag }})
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write

--- a/apt_sysvinit-utils.dockerfile
+++ b/apt_sysvinit-utils.dockerfile
@@ -3,6 +3,10 @@ ARG OS_TYPE
 
 FROM $OS_TYPE:$BASE_IMAGE_TAG
 
+# Re-declare OS_TYPE & BASE_IMAGE_TAG ARGS
+ARG OS_TYPE
+ARG BASE_IMAGE_TAG
+
 ENV container docker
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -10,6 +14,11 @@ RUN apt-get update \
     && apt-get install -y systemd sysvinit-utils util-linux locales locales-all wget iproute2 apt-transport-https\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ "$OS_TYPE" = "debian" ] && [ "$BASE_IMAGE_TAG" = "12" ]; then \
+        echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list; \
+        apt update; \
+    fi
 
 RUN locale-gen en_US.UTF-8  
 ENV LANG en_US.UTF-8  


### PR DESCRIPTION
## Summary
This PR is to fix the error introduced when added support for Debian-12.
Ref: https://github.com/puppetlabs/puppetlabs-apache/actions/runs/11460926405/job/31945092498

## Additional Context
This PR is to add `bookworm-backports` to sources so the package `libapache2-mod-apreq2` is available to install while running the tests.

