### PR TITLE
(CAT-2269) Address tjactions vulnerability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 2
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: step-security/changed-files
         with:
           json: true
           quotepath: false


### PR DESCRIPTION
Earlier last week, a vulnerability was discovered in the tjactions package. This commit addresses replaces the package with a safe alternative.
