### PR TITLE
(CAT-2269) Fix action typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 2
       - name: Get changed files
         id: changed-files
-        uses: step-security/changed-files
+        uses: step-security/changed-files@v45
         with:
           json: true
           quotepath: false


### PR DESCRIPTION
A previous PR replaced a vulnerable github action with a more secure one. However, the action name was missing a version and thus, it failed to load properly. This commit fixes that.

