### PR TITLE
(CAT-2286) Remove puppet 7 infrastructure

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -22,7 +22,7 @@ inputs:
     type: string
   ruby_version:
     required: true
-    default: "2.7"
+    default: "3.1"
     type: string
   path:
     description: 'working directory (default ${github.workspace}/acceptance_test)'

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -17,7 +17,7 @@ inputs:
     type: string
   ruby_version:
     required: true
-    default: "3.2"
+    default: "3.1"
     type: string
 
 runs:


### PR DESCRIPTION
Puppet 7 is EOL. Therefore, we can remove the test infrastructure for it. This commit aims to clear up any testing/config infrastructure related to Puppet 7 and, by extension, Ruby 2.7.

