### PR TITLE
(MAINT) Use an active image for workflows

### DIFF
--- a/.github/workflows/template_build_deploy.yml
+++ b/.github/workflows/template_build_deploy.yml
@@ -137,7 +137,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 10
       fail-fast: false


### PR DESCRIPTION
## Summary
Workflow is currently failing due to the deprecation of the image in Github Actions.

- [ ] 🟢 CI
