### PR TITLE
Fix platform architecture issues for version 7 systems

### DIFF
--- a/.github/workflows/template_build_deploy.yml
+++ b/.github/workflows/template_build_deploy.yml
@@ -205,6 +205,20 @@ jobs:
         name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # === PLATFORM FIX: conditionally override platforms input for build-push-action ===
+      - if: steps.compare_image.outputs.need_refresh || steps.compare_image.outcome == 'skipped'
+        name: Determine build platforms
+        id: set_platform
+        run: |
+          case "${{ matrix.image_tag }}" in
+            *centos:7*|*scientificlinux:7*|*oraclelinux:7*|*redhat:7*|amazonlinux:2)
+              echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "platforms=${{ matrix.platforms }}" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
       - if: steps.compare_image.outputs.need_refresh || steps.compare_image.outcome == 'skipped'
         name: Build ${{ matrix.image_tag }}
         id: build_image
@@ -217,7 +231,7 @@ jobs:
           push: false
           provenance: ${{ contains(env.REGISTRY, 'docker') }}
           tags: ${{ env.IMAGE_TAG }}
-          platforms: ${{ matrix.platforms }}
+          platforms: ${{ steps.set_platform.outputs.platforms }}
           build-args: |
             BASE_IMAGE_TAG=${{ matrix.base_tag }}
             OS_TYPE=${{ matrix.base_image }}
@@ -248,7 +262,7 @@ jobs:
           push: true
           tags: ${{ env.IMAGE_TAG }}
           provenance: ${{ contains(env.REGISTRY, 'docker') }}
-          platforms: ${{ matrix.platforms }}
+          platforms: ${{ steps.set_platform.outputs.platforms }}
           build-args: |
             BASE_IMAGE_TAG=${{ matrix.base_tag }}
             OS_TYPE=${{ matrix.base_image }}

--- a/.github/workflows/template_build_deploy.yml
+++ b/.github/workflows/template_build_deploy.yml
@@ -8,34 +8,8 @@ on:
         default: ""
         type: string
       dockerfile:
-        default: "      - if: matrix.refresh == false
-        name: Pull and compare image ${{ matrix.image_tag }}
-        id: compare_image
-        run: |
-          # Force AMD64 platform for problematic version 7 systems  
-          if [[ "${{ matrix.image_tag }}" =~ (centos|scientificlinux|oraclelinux|redhat):7 ]] || [[ "${{ matrix.image_tag }}" == "amazonlinux:2" ]]; then
-            if docker pull --platform linux/amd64 $IMAGE_TAG ; then
-              IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
-              if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
-                echo "no updates to base image since last build, aborting"
-                exit 0
-              fi
-              echo "::notice title=::rebuilding, base image_id does not match"
-            else
-              echo "::notice title=::proceeding, no existing image"
-            fi
-          else
-            if docker pull $IMAGE_TAG ; then
-              IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
-              if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
-                echo "no updates to base image since last build, aborting"
-                exit 0
-              fi
-              echo "::notice title=::rebuilding, base image_id does not match"
-            else
-              echo "::notice title=::proceeding, no existing image"
-            fi
-          fi: string
+        default: ""
+        type: string
       refresh:
         type: boolean
         default: false
@@ -196,29 +170,15 @@ jobs:
         name: Pull and compare image ${{ matrix.image_tag }}
         id: compare_image
         run: |
-          # Force AMD64 platform for problematic version 7 systems
-          if [[ "${{ matrix.image_tag }}" =~ (centos|scientificlinux|oraclelinux|redhat):7 ]] || [[ "${{ matrix.image_tag }}" == "amazonlinux:2" ]]; then
-            if docker pull --platform linux/amd64 $IMAGE_TAG ; then
-              IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
-              if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
-                echo "no updates to base image since last build, aborting"
-                exit 0
-              fi
-              echo "::notice title=::rebuilding, base image_id does not match"
-            else
-              echo "::notice title=::building, image not found in registry"
+          if docker pull $IMAGE_TAG ; then
+            IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
+            if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
+              echo "no updates to base image since last build, aborting"
+              exit 0
             fi
+            echo "::notice title=::rebuilding, base image_id does not match"
           else
-            if docker pull $IMAGE_TAG ; then
-              IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
-              if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
-                echo "no updates to base image since last build, aborting"
-                exit 0
-              fi
-              echo "::notice title=::rebuilding, base image_id does not match"
-            else
-              echo "::notice title=::building, image not found in registry"
-            fi
+            echo "::notice title=::building, image not found in registry"
           fi
           echo "need_refresh=true" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/template_build_deploy.yml
+++ b/.github/workflows/template_build_deploy.yml
@@ -8,8 +8,34 @@ on:
         default: ""
         type: string
       dockerfile:
-        default: ""
-        type: string
+        default: "      - if: matrix.refresh == false
+        name: Pull and compare image ${{ matrix.image_tag }}
+        id: compare_image
+        run: |
+          # Force AMD64 platform for problematic version 7 systems  
+          if [[ "${{ matrix.image_tag }}" =~ (centos|scientificlinux|oraclelinux|redhat):7 ]] || [[ "${{ matrix.image_tag }}" == "amazonlinux:2" ]]; then
+            if docker pull --platform linux/amd64 $IMAGE_TAG ; then
+              IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
+              if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
+                echo "no updates to base image since last build, aborting"
+                exit 0
+              fi
+              echo "::notice title=::rebuilding, base image_id does not match"
+            else
+              echo "::notice title=::proceeding, no existing image"
+            fi
+          else
+            if docker pull $IMAGE_TAG ; then
+              IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
+              if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
+                echo "no updates to base image since last build, aborting"
+                exit 0
+              fi
+              echo "::notice title=::rebuilding, base image_id does not match"
+            else
+              echo "::notice title=::proceeding, no existing image"
+            fi
+          fi: string
       refresh:
         type: boolean
         default: false
@@ -158,22 +184,41 @@ jobs:
 
       - name: Pull image ${{ matrix.base_image_tag }}
         run: |
-          docker image pull ${PULL_IMAGE}
+          # Force AMD64 platform for problematic version 7 systems
+          if [[ "${{ matrix.image_tag }}" =~ (centos|scientificlinux|oraclelinux|redhat):7 ]] || [[ "${{ matrix.image_tag }}" == "amazonlinux:2" ]]; then
+            docker image pull --platform linux/amd64 ${PULL_IMAGE}
+          else
+            docker image pull ${PULL_IMAGE}
+          fi
           echo "BASE_ID=$(docker images -q ${PULL_IMAGE})" >> $GITHUB_ENV
 
       - if: matrix.refresh == false
         name: Pull and compare image ${{ matrix.image_tag }}
         id: compare_image
         run: |
-          if docker pull $IMAGE_TAG ; then
-            IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
-            if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
-              echo "no updates to base image since last build, aborting"
-              exit 0
+          # Force AMD64 platform for problematic version 7 systems
+          if [[ "${{ matrix.image_tag }}" =~ (centos|scientificlinux|oraclelinux|redhat):7 ]] || [[ "${{ matrix.image_tag }}" == "amazonlinux:2" ]]; then
+            if docker pull --platform linux/amd64 $IMAGE_TAG ; then
+              IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
+              if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
+                echo "no updates to base image since last build, aborting"
+                exit 0
+              fi
+              echo "::notice title=::rebuilding, base image_id does not match"
+            else
+              echo "::notice title=::building, image not found in registry"
             fi
-            echo "::notice title=::rebuilding, base image_id does not match"
           else
-            echo "::notice title=::building, image not found in registry"
+            if docker pull $IMAGE_TAG ; then
+              IMAGE_BASE_ID=$(docker inspect ${IMAGE_TAG} --format "{{ index .Config.Labels \"base_image\"}}" || true)
+              if [[ "${IMAGE_BASE_ID}" == "${BASE_ID}" ]] ; then
+                echo "no updates to base image since last build, aborting"
+                exit 0
+              fi
+              echo "::notice title=::rebuilding, base image_id does not match"
+            else
+              echo "::notice title=::building, image not found in registry"
+            fi
           fi
           echo "need_refresh=true" >> $GITHUB_OUTPUT
 

--- a/yum_systemd.dockerfile
+++ b/yum_systemd.dockerfile
@@ -10,6 +10,7 @@ ARG BASE_IMAGE_TAG
 ENV container docker
 
 # Fix platform architecture issues for v7 systems with Docker platform specification
+# Trigger CI build to test platform-specific Docker pulls
 
 RUN echo "LC_ALL=en_US.utf-8" >> /etc/locale.conf
 

--- a/yum_systemd.dockerfile
+++ b/yum_systemd.dockerfile
@@ -9,7 +9,7 @@ ARG BASE_IMAGE_TAG
 
 ENV container docker
 
-# Test CentOS 7 with ubuntu-22.04 runner for compatibility
+# Fix platform architecture issues for v7 systems with Docker platform specification
 
 RUN echo "LC_ALL=en_US.utf-8" >> /etc/locale.conf
 


### PR DESCRIPTION
- Force --platform linux/amd64 for Docker pulls of problematic v7 systems
- Apply to centos:7, scientificlinux:7, oraclelinux:7, redhat:7, amazonlinux:2
- Ensures consistent AMD64 platform regardless of runner architecture
- Based on successful local testing with platform specification
