### PR TITLE
(PA-8419) Add Debian 13 (trixie) image

### DIFF
--- a/images.json
+++ b/images.json
@@ -24,6 +24,7 @@
     { "image": "debian",          "tag": "10",      "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64"],             "base_image": "debian",                "base_tag": "10" },
     { "image": "debian",          "tag": "11",      "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "debian",                "base_tag": "bullseye" },
     { "image": "debian",          "tag": "12",      "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "debian",                "base_tag": "12" },
+    { "image": "debian",          "tag": "13",      "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "debian",                "base_tag": "13", "puppet_collection": "puppetcore8" },
     { "image": "amazonlinux",     "tag": "2023",    "dockerfile": "yum_systemd",        "platforms": ["amd64", "arm64/v8"], "base_image": "amazonlinux",           "base_tag": "2023" },
     { "image": "amazonlinux",     "tag": "2",       "dockerfile": "yum_systemd_ssh",    "platforms": ["amd64"],             "base_image": "amazonlinux",           "base_tag": "2" },
     { "image": "fedora",          "tag": "36",      "dockerfile": "dnf_systemd",        "platforms": ["amd64"],             "base_image": "fedora",                "base_tag": "36" }


### PR DESCRIPTION
(PA-8354) Add Debian 13 (trixie) image

Register debian:13 in images.json so the existing build pipeline
produces and publishes a litmusimage/debian:13 image for both
amd64 and arm64/v8, mirroring the Debian 12 configuration.