### PR TITLE
(CAT-2614) switch EL8 images to iptables-legacy for Docker acceptance tests

### DIFF
--- a/dnf_systemd.dockerfile
+++ b/dnf_systemd.dockerfile
@@ -13,6 +13,22 @@ RUN dnf -y install openssh-server openssh-clients systemd initscripts glibc-lang
     ssh-keygen -A ; \
     touch /etc/ssh/ssh_host_dsa_key /etc/ssh/ssh_host_dsa_key.pub
 
+# On EL8 images, upgrade iptables and switch to the legacy backend.
+# iptables-nft (the EL8 default) fails with RULE_APPEND ENOENT on -m limit
+# rules when run inside Docker on a newer host kernel because the older
+# nft_compat ABI is incompatible. iptables-legacy bypasses nf_tables
+# entirely and avoids the issue. AlmaLinux 8 base images already ship a
+# recent enough iptables; Rocky 8 does not, so the update is required there.
+# The alternatives --set calls are idempotent if legacy is already default.
+RUN . /etc/os-release; \
+    if [ "${VERSION_ID%%.*}" = "8" ]; then \
+        dnf update -y iptables iptables-services 2>/dev/null || true; \
+        if [ -x /usr/sbin/iptables-legacy ]; then \
+            alternatives --set iptables  /usr/sbin/iptables-legacy; \
+            alternatives --set ip6tables /usr/sbin/ip6tables-legacy; \
+        fi; \
+    fi
+
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\

--- a/dnf_systemd.dockerfile
+++ b/dnf_systemd.dockerfile
@@ -24,8 +24,8 @@ RUN . /etc/os-release; \
     if [ "${VERSION_ID%%.*}" = "8" ]; then \
         dnf update -y iptables iptables-services 2>/dev/null || true; \
         if [ -x /usr/sbin/iptables-legacy ]; then \
-            alternatives --set iptables  /usr/sbin/iptables-legacy; \
-            alternatives --set ip6tables /usr/sbin/ip6tables-legacy; \
+            alternatives --set iptables  /usr/sbin/iptables-legacy  2>/dev/null || true; \
+            alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true; \
         fi; \
     fi
 

--- a/dnf_systemd.dockerfile
+++ b/dnf_systemd.dockerfile
@@ -21,7 +21,7 @@ RUN dnf -y install openssh-server openssh-clients systemd initscripts glibc-lang
 # recent enough iptables; Rocky 8 does not, so the update is required there.
 # The alternatives --set calls are idempotent if legacy is already default.
 RUN . /etc/os-release; \
-    if [ "${VERSION_ID%%.*}" = "8" ]; then \
+    if [ "${VERSION_ID%%.*}" = "8" ] && ( [ "$ID" = "rocky" ] || [ "$ID" = "almalinux" ] ); then \
         dnf update -y iptables iptables-services 2>/dev/null || true; \
         if [ -x /usr/sbin/iptables-legacy ]; then \
             alternatives --set iptables  /usr/sbin/iptables-legacy  2>/dev/null || true; \

--- a/yum_systemd.dockerfile
+++ b/yum_systemd.dockerfile
@@ -37,8 +37,8 @@ RUN . /etc/os-release 2>/dev/null || true; \
     if [ "${VERSION_ID%%.*}" = "8" ]; then \
         yum update -y iptables iptables-services 2>/dev/null || true; \
         if [ -x /usr/sbin/iptables-legacy ]; then \
-            alternatives --set iptables  /usr/sbin/iptables-legacy; \
-            alternatives --set ip6tables /usr/sbin/ip6tables-legacy; \
+            alternatives --set iptables  /usr/sbin/iptables-legacy  2>/dev/null || true; \
+            alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true; \
         fi; \
     fi
 

--- a/yum_systemd.dockerfile
+++ b/yum_systemd.dockerfile
@@ -29,6 +29,19 @@ fi
 
 RUN yum -y install openssh-server openssh-clients systemd initscripts glibc-langpack-en iproute wget; yum -y reinstall dbus; yum clean all; systemctl enable sshd.service
 
+# On EL8 images (CentOS Stream 8, OracleLinux 8, RHEL UBI 8), upgrade
+# iptables and switch to the legacy backend. iptables-nft fails with
+# RULE_APPEND ENOENT on -m limit rules inside Docker on newer host kernels
+# due to an nft_compat ABI mismatch. The legacy backend bypasses nf_tables.
+RUN . /etc/os-release 2>/dev/null || true; \
+    if [ "${VERSION_ID%%.*}" = "8" ]; then \
+        yum update -y iptables iptables-services 2>/dev/null || true; \
+        if [ -x /usr/sbin/iptables-legacy ]; then \
+            alternatives --set iptables  /usr/sbin/iptables-legacy; \
+            alternatives --set ip6tables /usr/sbin/ip6tables-legacy; \
+        fi; \
+    fi
+
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\

--- a/yum_systemd.dockerfile
+++ b/yum_systemd.dockerfile
@@ -34,7 +34,7 @@ RUN yum -y install openssh-server openssh-clients systemd initscripts glibc-lang
 # RULE_APPEND ENOENT on -m limit rules inside Docker on newer host kernels
 # due to an nft_compat ABI mismatch. The legacy backend bypasses nf_tables.
 RUN . /etc/os-release 2>/dev/null || true; \
-    if [ "${VERSION_ID%%.*}" = "8" ]; then \
+    if [ "${VERSION_ID%%.*}" = "8" ] && [ "$ID" = "centos" ]; then \
         yum update -y iptables iptables-services 2>/dev/null || true; \
         if [ -x /usr/sbin/iptables-legacy ]; then \
             alternatives --set iptables  /usr/sbin/iptables-legacy  2>/dev/null || true; \


### PR DESCRIPTION
## Summary

iptables-nft (the EL8 default) fails with RULE_APPEND ENOENT on rules using -m limit when the container runs on a modern Ubuntu host kernel. The root cause is an nft_compat ABI incompatibility between the old iptables 1.8.5-11 userspace in the EL8 base images and the host kernel's nf_tables implementation. Switching to iptables-legacy bypasses nf_tables entirely and avoids the issue.

Changes:
- dnf_systemd.dockerfile: for VERSION_ID 8.x (Rocky 8, AlmaLinux 8) run `dnf update iptables` to pick up the legacy binary then set it as the alternatives default. AlmaLinux 8 already has it; Rocky 8 does not.
- yum_systemd.dockerfile: same for VERSION_ID 8.x (CentOS Stream 8, OracleLinux 8, RHEL UBI 8) using yum.

The alternatives --set calls are idempotent when legacy is already default.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
