### PR TITLE
fix: replace 'last' with 'uname -a' as smoke-test liveness probe

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -67,7 +67,7 @@ runs:
       shell: bash
       run: |
         echo "testing bolt command"
-        bundle exec bolt command run 'last' -t all
+        bundle exec bolt command run 'uname -a' -t all
         echo "testing bolt task"
         bundle exec bolt task run litmusimage::smoke -t all
         echo "testing SLES repository configuration"


### PR DESCRIPTION
'last' is no longer present by default on Debian 13 (trixie), where it was moved out of sysvinit-utils into the wtmpdb package. 'uname -a' is universally available, more informative in CI logs, and unaffected by distro packaging changes.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
