### PR TITLE
feat: install puppet-agent from Puppetcore, gated by environment

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -27,6 +27,16 @@ inputs:
   path:
     description: 'working directory (default ${github.workspace}/acceptance_test)'
     type: string
+  collection:
+    description: 'puppet_agent collection (e.g. puppetcore8); empty = puppet_agent default'
+    required: false
+    default: ""
+    type: string
+  forge_token:
+    description: 'Puppetcore Forge token; required when collection starts with puppetcore'
+    required: false
+    default: ""
+    type: string
 
 runs:
   using: "composite"
@@ -48,6 +58,15 @@ runs:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.ref }}
         path: ${{ steps.vars.outputs.working-directory }}
+
+    - name: Configure forge authentication
+      if: inputs.forge_token != ''
+      shell: bash
+      env:
+        FORGE_TOKEN: ${{ inputs.forge_token }}
+      run: |
+        echo "PUPPET_FORGE_TOKEN=$FORGE_TOKEN" >> "$GITHUB_ENV"
+        echo "BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM=forge-key:$FORGE_TOKEN" >> "$GITHUB_ENV"
 
     - name: Setup Ruby
       uses: "ruby/setup-ruby@v1"
@@ -101,7 +120,25 @@ runs:
     - name: Install Agent
       working-directory: ${{ steps.vars.outputs.working-directory }}
       shell: bash
-      run: bundle exec rake litmus:install_agent
+      run: |
+        case "${{ inputs.collection }}" in
+          puppetcore*)
+            # install_shell.sh can't bootstrap on codenames where Puppetcore hasn't
+            # published /public/puppet<N>-release-<codename>.deb (e.g. trixie).
+            # See .github/actions/install-puppetcore/install_puppetcore_agent.sh.
+            bundle exec bolt script run \
+              "${{ github.action_path }}/../install-puppetcore/install_puppetcore_agent.sh" \
+              "${{ inputs.collection }}" "${{ inputs.forge_token }}" \
+              --targets all --tmpdir /tmp \
+              --inventoryfile spec/fixtures/litmus_inventory.yaml
+            ;;
+          ?*)
+            bundle exec rake "litmus:install_agent[${{ inputs.collection }}]"
+            ;;
+          *)
+            bundle exec rake litmus:install_agent
+            ;;
+        esac
 
     - name: Install Module
       working-directory: ${{ steps.vars.outputs.working-directory }}

--- a/.github/actions/install-puppetcore/install_puppetcore_agent.sh
+++ b/.github/actions/install-puppetcore/install_puppetcore_agent.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Workaround for Puppetcore not publishing /public/puppet8-release-trixie.deb.
+# Trixie runtime packages exist in apt-puppetcore.puppet.com (verified via
+# InRelease manifest: .refs/puppet8/puppet-agent_8.19.0-1trixie_amd64.deb etc.),
+# but the unauthenticated bootstrap config-deb that install_shell.sh fetches
+# does not. We install the bookworm bootstrap (which exists and just drops
+# keyring + sources.list + auth.conf), then rewrite the codename so apt
+# resolves against the host's actual suite.
+#
+# Remove this script and revert to litmus:install_agent once Puppetcore
+# publishes puppet8-release-<codename>.deb to /public/ for trixie.
+#
+# Usage: install_puppetcore_agent.sh <collection> <forge_token>
+
+set -euo pipefail
+
+COLLECTION="${1:?collection arg required}"
+TOKEN="${2:?forge token arg required}"
+
+. /etc/os-release
+case "${ID:-}" in debian|ubuntu) ;; *)
+  echo "Unsupported OS for puppetcore bootstrap workaround: ID=${ID:-unknown}" >&2
+  exit 2
+  ;;
+esac
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y --no-install-recommends ca-certificates curl
+
+curl -fsSL -o /tmp/puppet-release.deb \
+  "https://apt-puppetcore.puppet.com/public/${COLLECTION/core/}-release-bookworm.deb"
+dpkg -i /tmp/puppet-release.deb
+rm -f /tmp/puppet-release.deb
+
+sed -i "s/ bookworm / ${VERSION_CODENAME} /" \
+  /etc/apt/sources.list.d/puppet8-release.list
+
+auth_conf="/etc/apt/auth.conf.d/apt-puppetcore-puppet.conf"
+sed -i '/^#\?login/d; /^#\?password/d' "$auth_conf"
+printf 'login forge-key\npassword %s\n' "$TOKEN" >> "$auth_conf"
+chmod 0600 "$auth_conf"
+
+apt-get update
+apt-get install -y puppet-agent
+
+# Mirror puppet_litmus's configure_path: write /etc/environment so PAM exports
+# /opt/puppetlabs/puppet/bin on subsequent SSH sessions. bolt run_command uses
+# non-login shells where /etc/profile.d/puppet-agent.sh isn't sourced, so the
+# downstream `puppet module install` step would otherwise not find the binary.
+echo "PATH=$PATH:/opt/puppetlabs/puppet/bin" > /etc/environment
+
+/opt/puppetlabs/bin/puppet --version

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,4 +9,5 @@ jobs:
     uses: ./.github/workflows/template_build_deploy.yml
     with:
       image: .*
+      gated: false
     secrets: inherit

--- a/.github/workflows/template_build_deploy.yml
+++ b/.github/workflows/template_build_deploy.yml
@@ -28,6 +28,10 @@ on:
       acceptance_test:
         default: ""
         type: string
+      gated:
+        description: "gate Puppetcore-using matrix entries behind the puppetcore environment (required reviewers). Set false for trusted workflows like the nightly cron."
+        default: true
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -134,6 +138,11 @@ jobs:
     needs: select
     name: image (${{ matrix.image_tag }})
     timeout-minutes: 15
+    # Only matrix entries with `puppet_collection` set in images.json release
+    # PUPPETCORE_TOKEN, and only when `gated` is true (default). Nightly cron
+    # passes gated=false to skip the approval prompt on those entries; it
+    # doesn't run acceptance anyway so it doesn't need the token.
+    environment: ${{ inputs.gated && matrix.puppet_collection != '' && 'puppetcore' || '' }}
     permissions:
       contents: read
       packages: write
@@ -232,6 +241,8 @@ jobs:
           repo: ${{ inputs.acceptance_test }}
           provision_task: ${{ inputs.provision_task }}
           provision_module: ${{ inputs.provision_module }}
+          collection: ${{ matrix.puppet_collection || '' }}
+          forge_token: ${{ matrix.puppet_collection != '' && secrets.PUPPETCORE_TOKEN || '' }}
 
       - if: steps.build_image.outcome == 'success' && needs.select.outputs.push == 'true'
         name: Push ${{ matrix.image_tag }} to ${{ env.REGISTRY }}/${{ env.REPOSITORY }}


### PR DESCRIPTION
Smoke and acceptance actions now run litmus:install_agent[puppetcore8] with PUPPET_FORGE_TOKEN scoped to the install step only. The images job in template_build_deploy.yml runs under the puppetcore environment so PUPPETCORE_TOKEN releases only after a maintainer approves the run - closes the fork-PR exfiltration path. Nightly cron passes gated: false to skip the approval gate since it runs in a trusted main-branch context.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
