### PR TITLE
fix: switch OracleLinux 8 to dnf_systemd to fix SSH auth failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Images get [uploaded automatically][2] and are rebuilt [nightly if necessary][3]
 | sles            | 15      | zypper_systemd     | registry.suse.com/suse/sle15             | 15.5     |
 | oraclelinux     | 6       | yum_initd          | oraclelinux                              | 6        |
 | oraclelinux     | 7       | yum_systemd        | oraclelinux                              | 7        |
-| oraclelinux     | 8       | yum_systemd        | oraclelinux                              | 8        |
+| oraclelinux     | 8       | dnf_systemd        | oraclelinux                              | 8        |
 | oraclelinux     | 9       | yum_systemd        | oraclelinux                              | 9        |
 | rockylinux      | 8       | yum_systemd        | rockylinux/rockylinux                    | 8        |
 | rockylinux      | 9       | yum_systemd        | rockylinux/rockylinux                    | 9        |

--- a/images.json
+++ b/images.json
@@ -12,7 +12,7 @@
     { "image": "scientificlinux", "tag": "7",       "dockerfile": "yum_systemd_ssh",    "platforms": ["amd64"],             "base_image": "scientificlinux/sl",    "base_tag": "7" },
     { "image": "oraclelinux",     "tag": "6",       "dockerfile": "yum_initd",          "platforms": ["amd64"],             "base_image": "oraclelinux",           "base_tag": "6" },
     { "image": "oraclelinux",     "tag": "7",       "dockerfile": "yum_systemd_ssh",    "platforms": ["amd64", "arm64/v8"], "base_image": "oraclelinux",           "base_tag": "7" },
-    { "image": "oraclelinux",     "tag": "8",       "dockerfile": "yum_systemd",        "platforms": ["amd64", "arm64/v8"], "base_image": "oraclelinux",           "base_tag": "8" },
+    { "image": "oraclelinux",     "tag": "8",       "dockerfile": "dnf_systemd",        "platforms": ["amd64", "arm64/v8"], "base_image": "oraclelinux",           "base_tag": "8" },
     { "image": "oraclelinux",     "tag": "9",       "dockerfile": "dnf_systemd",        "platforms": ["amd64", "arm64/v8"], "base_image": "oraclelinux",           "base_tag": "9" },
     { "image": "rockylinux",      "tag": "8",       "dockerfile": "dnf_systemd",        "platforms": ["amd64", "arm64/v8"], "base_image": "rockylinux/rockylinux", "base_tag": "8" },
     { "image": "rockylinux",      "tag": "9",       "dockerfile": "dnf_systemd",        "platforms": ["amd64", "arm64/v8"], "base_image": "rockylinux/rockylinux", "base_tag": "9" },


### PR DESCRIPTION
## Summary
- OracleLinux 8 (`images.json`/`README.md`) was building from `yum_systemd.dockerfile`, which installs `openssh-server` at image-build time but never generates SSH host keys — that's deferred to `puppet_litmus`'s docker provisioner (`provision` module's `tasks/docker.rb`), which runs `ssh-keygen -t rsa`/`-t dsa` live on every single container provision.
- This has been the cause of the OracleLinux-8 acceptance job hanging ~15+ minutes at "Provision environment" and then failing SSH auth (`Authentication failed for user root@localhost`) on every nightly run across dependent modules (confirmed via `puppetlabs-puppet_authorization`'s nightly workflow: OracleLinux-8 failed 8/8 consecutive nights while every sibling platform — including CentOS-8 and RedHat-8, which share the same `yum_systemd.dockerfile` — passed).
- Switched OracleLinux 8 to `dnf_systemd.dockerfile`, which already bakes `ssh-keygen -A` into the image at build time (used today by Rocky/AlmaLinux 8/9, RHEL 9, OracleLinux 9) while still running full `systemd` as PID1 — so it fixes the runtime-keygen dependency without dropping systemd support the way the older `yum_systemd_ssh` variant would have.
- This mirrors `fd4c4bc` (CAT-2416), which fixed the identical symptom on AlmaLinux 8 by switching dockerfile variants.

## Verification
Built and ran both candidate fixes locally against `oraclelinux:8` and replayed `provision`'s `docker.rb` `install_ssh_components` steps against each:
- `dnf_systemd.dockerfile`: host keys (RSA/DSA/ECDSA/ED25519) present at container boot, `systemctl is-system-running` reaches `running` immediately, full systemd confirmed as PID1 (`/lib/systemd/systemd`), and `root`/`root` SSH password auth succeeds immediately with no runtime keygen/network dependency.

## Test plan
- [ ] CI builds the updated `oraclelinux:8` image successfully for both `amd64` and `arm64/v8`
- [ ] Downstream nightly acceptance run for a module testing OracleLinux 8 (e.g. `puppetlabs-puppet_authorization`) passes after this image is published