### PR TITLE
Add Ubuntu 26.04 image

### DIFF
--- a/images.json
+++ b/images.json
@@ -3,6 +3,7 @@
     { "image": "ubuntu",          "tag": "20.04",   "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "ubuntu",                "base_tag": "20.04" },
     { "image": "ubuntu",          "tag": "22.04",   "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "ubuntu",                "base_tag": "22.04" },
     { "image": "ubuntu",          "tag": "24.04",   "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "ubuntu",                "base_tag": "24.04" },
+    { "image": "ubuntu",          "tag": "26.04",   "dockerfile": "apt_sysvinit-utils", "platforms": ["amd64", "arm64/v8"], "base_image": "ubuntu",                "base_tag": "26.04", "puppet_collection": "puppetcore8" },
     { "image": "centos",          "tag": "6",       "dockerfile": "yum_initd",          "platforms": ["amd64"],             "base_image": "centos",                "base_tag": "6" },
     { "image": "centos",          "tag": "7",       "dockerfile": "yum_systemd_ssh",    "platforms": ["amd64"],             "base_image": "centos",                "base_tag": "7" },
     { "image": "centos",          "tag": "stream8", "dockerfile": "yum_systemd",        "platforms": ["amd64", "arm64/v8"], "base_image": "quay.io/centos/centos", "base_tag": "stream8" },


### PR DESCRIPTION
Add Ubuntu 26.04 image

Register ubuntu:26.04 in images.json so the existing build pipeline produces and publishes a litmusimage/ubuntu:26.04 image for both amd64 and arm64/v8, mirroring the Ubuntu 24.04 configuration.

Uses the `puppetcore8` collection because `apt.puppet.com` does not yet publish a `puppet-release` package for the `resolute` (26.04) codename — the default install script 404s trying to fetch it. Puppetcore's nightly mirror already supports it, same as the Debian 13 (trixie) image (#121).

Needed to run acceptance tests for Ubuntu 26.04 support added in https://github.com/puppetlabs/puppetlabs-postgresql/pull/1688.

Draft — opened for review before marking ready.